### PR TITLE
Automatic binding expectations per subject

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'mumukit', github: 'mumuki/mumukit', tag: 'v0.4.0'
+gem 'mumukit', github: 'mumuki/mumukit', tag: 'v0.6.0'
 gem 'mumukit-inspection', github: 'uqbar-project/mumukit-inspection', branch: 'master'
 gem 'stones-spec', github: 'uqbar-project/stones-spec', branch: 'master'
 gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,11 @@ GIT
 
 GIT
   remote: git://github.com/mumuki/mumukit.git
-  revision: 9743dc9108264586d5fc1d4246847e0b70d82619
-  tag: v0.4.0
+  revision: 26f6c572de20d66af52b721b91baee7c34176414
+  tag: v0.6.0
   specs:
-    mumukit (0.4.0)
+    mumukit (0.6.0)
+      i18n (~> 0.7)
       sinatra (~> 1.4)
 
 GIT
@@ -51,7 +52,7 @@ GEM
     mime-types (2.5)
     minitest (5.5.0)
     netrc (0.10.3)
-    rack (1.6.1)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
     rake (10.4.2)

--- a/lib/expectations_runner.rb
+++ b/lib/expectations_runner.rb
@@ -4,6 +4,7 @@ require 'stones-spec'
 require 'yaml'
 
 require_relative 'subject_extensions'
+require_relative 'with_test_parser'
 
 module EvalExpectationsOnAST
   def eval_in_gobstones(binding, ast)
@@ -68,6 +69,7 @@ end
 class ExpectationsRunner
   include Mumukit
   include StonesSpec::WithTempfile
+  include WithTestParser
 
   def run_expectations!(request)
     content = request[:content]
@@ -78,13 +80,13 @@ class ExpectationsRunner
     end
 
     ast = generate_ast! content
-    all_expectations = expectations + (default_expectations_for YAML.load request[:test])
+    all_expectations = expectations + (default_expectations_for parse_test request)
 
     all_expectations.map { |exp| {'expectation' => exp, 'result' => run_expectation!(exp, ast)} }
   end
 
   def default_expectations_for(test)
-    StonesSpec::Subject.from(test['subject'], StonesSpec::Language::Gobstones).default_expectations
+    StonesSpec::Subject.from(test[:subject], StonesSpec::Language::Gobstones).default_expectations
   end
 
   def run_expectation!(expectation, ast)

--- a/lib/expectations_runner.rb
+++ b/lib/expectations_runner.rb
@@ -68,13 +68,13 @@ class ExpectationsRunner
   include Mumukit
   include StonesSpec::WithTempfile
 
-  def run_expectations!(expectations, content, _extra='')
-    if content.strip.empty?
-      return expectations.map { |exp| {'expectation' => exp, 'result' => false } }
+  def run_expectations!(request)
+    if request[:content].strip.empty?
+      return request[:expectations].map { |exp| {'expectation' => exp, 'result' => false } }
     end
 
-    ast = generate_ast!(content)
-    expectations.map { |exp| {'expectation' => exp, 'result' => run_expectation!(exp, ast)} }
+    ast = generate_ast! request[:content]
+    request[:expectations].map { |exp| {'expectation' => exp, 'result' => run_expectation!(exp, ast)} }
   end
 
   def run_expectation!(expectation, ast)

--- a/lib/subject_extensions.rb
+++ b/lib/subject_extensions.rb
@@ -1,21 +1,23 @@
+module WithDefaultExpectations
+  def default_expectations
+    [{ 'binding' => 'program', 'inspection' => 'Not:HasBinding' }, { 'binding' => "#{@name}", 'inspection' => 'HasBinding' }]
+  end
+end
+
 module StonesSpec::Subject
   class Procedure
+    include WithDefaultExpectations
+
     def ast_regexp
       /AST\(procedure\s*#{@name}/
-    end
-
-    def default_expectations
-      [{ 'binding' => 'program', 'inspection' => 'Not:HasBinding' }, { 'binding' => "#{@name}", 'inspection' => 'HasBinding' }]
     end
   end
 
   class Function
+    include WithDefaultExpectations
+
     def ast_regexp
       /AST\(function\s*#{@name}/
-    end
-
-    def default_expectations
-      []
     end
   end
 

--- a/lib/subject_extensions.rb
+++ b/lib/subject_extensions.rb
@@ -5,7 +5,7 @@ module StonesSpec::Subject
     end
 
     def default_expectations
-      []
+      [{ 'binding' => 'program', 'inspection' => 'Not:HasBinding' }, { 'binding' => "#{@name}", 'inspection' => 'HasBinding' }]
     end
   end
 

--- a/lib/subject_extensions.rb
+++ b/lib/subject_extensions.rb
@@ -3,17 +3,29 @@ module StonesSpec::Subject
     def ast_regexp
       /AST\(procedure\s*#{@name}/
     end
+
+    def default_expectations
+      []
+    end
   end
 
   class Function
     def ast_regexp
       /AST\(function\s*#{@name}/
     end
+
+    def default_expectations
+      []
+    end
   end
 
   module Program
     def self.ast_regexp
       /AST\(entrypoint\s*program/
+    end
+
+    def self.default_expectations
+      [{ 'binding' => 'program', 'inspection' => 'HasBinding' }]
     end
   end
 end

--- a/lib/subject_extensions.rb
+++ b/lib/subject_extensions.rb
@@ -1,6 +1,9 @@
 module WithDefaultExpectations
   def default_expectations
-    [{ 'binding' => 'program', 'inspection' => 'Not:HasBinding' }, { 'binding' => "#{@name}", 'inspection' => 'HasBinding' }]
+    [
+      { 'binding' => 'program', 'inspection' => 'Not:HasBinding' },
+      { 'binding' => "#{@name}", 'inspection' => 'HasBinding' }
+    ]
   end
 end
 

--- a/lib/test_compiler.rb
+++ b/lib/test_compiler.rb
@@ -7,9 +7,9 @@ require_relative 'with_source_concatenation'
 class TestCompiler < Mumukit::Stub
   include WithSourceConcatenation
 
-  def create_compilation!(test_src, extra_src, content_src)
-    test = YAML::load test_src
-    test['source'] = concatenate_source(content_src, extra_src)
+  def create_compilation!(request)
+    test = YAML::load request[:test]
+    test['source'] = concatenate_source request[:content], request[:extra]
     test['check_head_position'] = !!test['check_head_position']
     test.deep_symbolize_keys
   end

--- a/lib/test_compiler.rb
+++ b/lib/test_compiler.rb
@@ -1,16 +1,14 @@
 require 'mumukit'
-require 'yaml'
-require 'active_support/core_ext/hash'
 
-require_relative 'with_source_concatenation'
+require_relative 'with_test_parser'
 
 class TestCompiler < Mumukit::Stub
-  include WithSourceConcatenation
+  include WithTestParser
 
   def create_compilation!(request)
-    test = YAML::load request[:test]
-    test['source'] = concatenate_source request[:content], request[:extra]
-    test['check_head_position'] = !!test['check_head_position']
-    test.deep_symbolize_keys
+    test = parse_test request
+    test[:source] = "#{request[:content]}\n#{request[:extra]}"
+    test[:check_head_position] = !!test[:check_head_position]
+    test
   end
 end

--- a/lib/with_source_concatenation.rb
+++ b/lib/with_source_concatenation.rb
@@ -1,5 +1,0 @@
-module WithSourceConcatenation
-  def concatenate_source(content_src, extra_src)
-    "#{content_src}\n#{extra_src}"
-  end
-end

--- a/lib/with_test_parser.rb
+++ b/lib/with_test_parser.rb
@@ -1,0 +1,8 @@
+require 'yaml'
+require 'active_support/core_ext/hash'
+
+module WithTestParser
+  def parse_test(request)
+    (YAML.load request[:test]).deep_symbolize_keys
+  end
+end

--- a/spec/expectations_runner_spec.rb
+++ b/spec/expectations_runner_spec.rb
@@ -149,6 +149,17 @@ describe ExpectationsRunner do
       it { expect(result).to include({ 'expectation' => not_has_binding_program, 'result' => true }) }
       it { expect(result).to include({ 'expectation' => has_binding_procedure, 'result' => true }) }
     end
+
+    context 'when the subject is a function' do
+      let(:function) { 'function dummy() { return(25) }' }
+      let(:not_has_binding_program) { {'binding' => 'program', 'inspection' => 'Not:HasBinding' }  }
+      let(:has_binding_function) { {'binding' => 'dummy', 'inspection' => 'HasBinding' }  }
+
+      let(:result) { runner.run_expectations! content: function, expectations: [], test: 'subject: dummy' }
+
+      it { expect(result).to include({ 'expectation' => not_has_binding_program, 'result' => true }) }
+      it { expect(result).to include({ 'expectation' => has_binding_function, 'result' => true }) }
+    end
   end
 
   context 'when procedure definitions are missing' do

--- a/spec/expectations_runner_spec.rb
+++ b/spec/expectations_runner_spec.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :comply_with do |expectation|
   end
 
   define_method :run_expectation! do |code, expected_result|
-    runner.run_expectations!([expectation], code) == [{'expectation' => expectation, 'result' => expected_result}]
+    runner.run_expectations!(expectations: [expectation], content: code) == [{'expectation' => expectation, 'result' => expected_result}]
   end
 end
 

--- a/spec/expectations_runner_spec.rb
+++ b/spec/expectations_runner_spec.rb
@@ -138,6 +138,17 @@ describe ExpectationsRunner do
 
       it { expect(result).to eq [{ 'expectation' => has_binding_program, 'result' => true }] }
     end
+
+    context 'when the subject is a procedure' do
+      let(:procedure) { 'procedure Dummy() {}' }
+      let(:not_has_binding_program) { {'binding' => 'program', 'inspection' => 'Not:HasBinding' }  }
+      let(:has_binding_procedure) { {'binding' => 'Dummy', 'inspection' => 'HasBinding' }  }
+
+      let(:result) { runner.run_expectations! content: procedure, expectations: [], test: 'subject: Dummy' }
+
+      it { expect(result).to include({ 'expectation' => not_has_binding_program, 'result' => true }) }
+      it { expect(result).to include({ 'expectation' => has_binding_procedure, 'result' => true }) }
+    end
   end
 
   context 'when procedure definitions are missing' do

--- a/spec/expectations_runner_spec.rb
+++ b/spec/expectations_runner_spec.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :comply_with do |expectation|
   end
 
   define_method :run_expectation! do |code, expected_result|
-    runner.run_expectations!(expectations: [expectation], content: code) == [{'expectation' => expectation, 'result' => expected_result}]
+    runner.run_expectations!(expectations: [expectation], content: code, test: 'dummy: true').include?({'expectation' => expectation, 'result' => expected_result})
   end
 end
 
@@ -126,6 +126,17 @@ describe ExpectationsRunner do
 
       it { expect(function).to comply_with has_arity_0 }
       it { expect(function).not_to comply_with has_arity_2 }
+    end
+  end
+
+  describe 'automatic expectations' do
+    context 'when the subject is program' do
+      let(:program) { 'program {}' }
+      let(:has_binding_program) { {'binding' => 'program', 'inspection' => 'HasBinding' }  }
+
+      let(:result) { runner.run_expectations! content: program, expectations: [], test: 'dummy: true' }
+
+      it { expect(result).to eq [{ 'expectation' => has_binding_program, 'result' => true }] }
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,6 +53,6 @@ examples:
 
     it { expect(response[:status]).to eq 'passed' }
     it { expect(response[:result]).to include '<div>' }
-    it { expect(response[:expectation_results]).to eq [{:binding=>'PonerUnaDeCada', :inspection=>'HasUsage', :result=>:passed}] }
+    it { expect(response[:expectation_results]).to eq [{:binding => 'PonerUnaDeCada', :inspection => 'HasUsage', :result => :passed}] }
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,18 +8,19 @@ describe 'runner' do
     @pid = Process.spawn 'rackup -p 4567', err: '/dev/null'
     sleep 3
   end
+
   after(:all) { Process.kill 'TERM', @pid }
 
   context 'when submission is ok' do
-    it 'answers a valid hash' do
-      response = bridge.run_tests!(content: '
+    let(:content) { '
 procedure PonerUnaDeCada() {
     Poner (Rojo)
     Poner (Azul)
     Poner (Negro)
     Poner (Verde)
-}
-', extra: '', test: '
+}' }
+
+    let(:test) { '
 check_head_position: true
 
 subject: PonerUnaDeCada
@@ -43,10 +44,15 @@ examples:
      GBB/1.0
      size 5 5
      cell 3 3 Azul 1 Rojo 1 Verde 1 Negro 1
-     head 3 3')
+     head 3 3' }
 
-      expect(response[:status]).to eq 'passed'
-      expect(response[:result]).to include '<div>'
-    end
+    let(:expectations) { [{binding: 'PonerUnaDeCada', inspection: 'HasUsage'}] }
+    let(:extra) { '' }
+
+    let(:response) { bridge.run_tests! content: content, extra: extra, expectations: expectations, test: test }
+
+    it { expect(response[:status]).to eq 'passed' }
+    it { expect(response[:result]).to include '<div>' }
+    it { expect(response[:expectation_results]).to eq [{:binding=>'PonerUnaDeCada', :inspection=>'HasUsage', :result=>:passed}] }
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,6 +53,6 @@ examples:
 
     it { expect(response[:status]).to eq 'passed' }
     it { expect(response[:result]).to include '<div>' }
-    it { expect(response[:expectation_results]).to eq [{:binding => 'PonerUnaDeCada', :inspection => 'HasUsage', :result => :passed}] }
+    it { expect(response[:expectation_results]).to include({:binding => 'PonerUnaDeCada', :inspection => 'HasUsage', :result => :passed}) }
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,6 +53,6 @@ examples:
 
     it { expect(response[:status]).to eq 'passed' }
     it { expect(response[:result]).to include '<div>' }
-    it { expect(response[:expectation_results]).to include({:binding => 'PonerUnaDeCada', :inspection => 'HasUsage', :result => :passed}) }
+    it { expect(response[:expectation_results]).to include({binding: 'PonerUnaDeCada', inspection: 'HasUsage', result: :passed}) }
   end
 end

--- a/spec/test_compiler_spec.rb
+++ b/spec/test_compiler_spec.rb
@@ -6,6 +6,7 @@ require_relative '../lib/test_compiler'
 describe TestCompiler do
   context '#compile' do
     let(:compiler) { TestCompiler.new }
+    let(:output) { compiler.create_compilation!({test: test_file, extra: 'extra', content: 'content'}) }
 
     context 'when check_head_position is true' do
       let(:test_file) {
@@ -16,7 +17,7 @@ describe TestCompiler do
    - initial_board: initial
      final_board: final'
       }
-      let(:output) { compiler.create_compilation!(test_file, 'extra', 'content') }
+
       it {
         expect(output).to eq({
           source: "content\nextra",
@@ -34,7 +35,7 @@ describe TestCompiler do
    - initial_board: initial
      final_board: final'
       }
-      let(:output) { compiler.create_compilation!(test_file, 'extra', 'content') }
+
       it {
         expect(output).to eq({
           source: "content\nextra",
@@ -50,7 +51,7 @@ describe TestCompiler do
    - initial_board: initial
      final_board: final'
       }
-      let(:output) { compiler.create_compilation!(test_file, 'extra', 'content') }
+
       it {
         expect(output).to eq({
           source: "content\nextra",
@@ -71,7 +72,7 @@ describe TestCompiler do
       - 3
       - Rojo'
       }
-      let(:output) { compiler.create_compilation!(test_file, 'extra', 'content') }
+
       it {
         expect(output).to eq({
           source: "content\nextra",


### PR DESCRIPTION
Closes #50 
Closes #42 

After merging this, we should remove the default expectations from all exercises.